### PR TITLE
Fix missing code snippet in Startup.Configure

### DIFF
--- a/aspnetcore/tutorials/signalr-blazor-webassembly.md
+++ b/aspnetcore/tutorials/signalr-blazor-webassembly.md
@@ -187,7 +187,7 @@ dotnet add Client package Microsoft.AspNetCore.SignalR.Client
 
 1. `Startup.Configure` で、コントローラーのエンドポイントとクライアント側のフォールバックのエンドポイントの間に、ハブのエンドポイントを追加します。
 
-   [!code-csharp[](signalr-blazor-webassembly/samples/3.x/BlazorSignalRApp/Server/Startup.cs?name=snippet_UseEndpoints&highlight=4)]
+   [!code-csharp[](signalr-blazor-webassembly/samples/3.x/BlazorSignalRApp/Server/Startup.cs?name=snippet_Configure&highlight=3,25)]
 
 ## <a name="add-razor-component-code-for-chat"></a>チャット用の Razor コンポーネント コードを追加する
 


### PR DESCRIPTION
I am not sure why this is snippet reference is inconsistent in the ja-JP version (and missing in the page view), so I synchronized back the en-US version snippet to ensure it is consistent.

提案を送信するための役立つ情報:
1.[ローカライズ スタイル ガイドのクイック スタート](https://docs.microsoft.com/globalization/localization/styleguides) に移動して、Microsoft スタイル ガイドの **最も重要なルール上位 10 個** をご確認ください。
2.[Microsoft ランゲージ ポータル](https://www.microsoft.com/language) に移動して、Microsoft 製品間での **標準化された用語の翻訳** をご確認ください。
